### PR TITLE
Minor quality of life improvement

### DIFF
--- a/src/main/java/de/tobfal/basicgens/block/GlowstoneGeneratorBlock.java
+++ b/src/main/java/de/tobfal/basicgens/block/GlowstoneGeneratorBlock.java
@@ -1,15 +1,20 @@
 package de.tobfal.basicgens.block;
 
 import de.tobfal.basicgens.block.entity.GlowstoneGeneratorBlockEntity;
+import de.tobfal.basicgens.init.Config;
 import de.tobfal.basicgens.init.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -27,6 +32,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class GlowstoneGeneratorBlock extends BaseEntityBlock {
@@ -36,6 +43,15 @@ public class GlowstoneGeneratorBlock extends BaseEntityBlock {
     public GlowstoneGeneratorBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH));
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void appendHoverText(ItemStack stack, @Nullable BlockGetter blockGetter, List<Component> components, TooltipFlag tooltipFlag) {
+        components.add(Component.literal("Converts hot fluids into RF power."));
+        components.add(Component.literal("Capacity: " + Config.GLOWSTONE_GENERATOR_CAPACITY.get()));
+        components.add(Component.literal("RF/t: " + Config.GLOWSTONE_GENERATOR_PERTICK.get()));
+        components.add(Component.literal("Output/t: " + Config.GLOWSTONE_GENERATOR_TRANSFER.get()));
     }
 
     public static final VoxelShape SHAPE = Stream.of(

--- a/src/main/java/de/tobfal/basicgens/block/GoldGeneratorBlock.java
+++ b/src/main/java/de/tobfal/basicgens/block/GoldGeneratorBlock.java
@@ -2,15 +2,20 @@ package de.tobfal.basicgens.block;
 
 import de.tobfal.basicgens.block.entity.GeneratorBlockEntityBase;
 import de.tobfal.basicgens.block.entity.GoldGeneratorBlockEntity;
+import de.tobfal.basicgens.init.Config;
 import de.tobfal.basicgens.init.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -27,6 +32,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class GoldGeneratorBlock extends BaseEntityBlock {
@@ -36,6 +43,15 @@ public class GoldGeneratorBlock extends BaseEntityBlock {
     public GoldGeneratorBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH));
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void appendHoverText(ItemStack stack, @Nullable BlockGetter blockGetter, List<Component> components, TooltipFlag tooltipFlag) {
+        components.add(Component.literal("Converts burnable items to RF power."));
+        components.add(Component.literal("Capacity: " + Config.GOLD_GENERATOR_CAPACITY.get()));
+        components.add(Component.literal("RF/t: " + Config.GOLD_GENERATOR_PERTICK.get()));
+        components.add(Component.literal("Output/t: " + Config.GOLD_GENERATOR_TRANSFER.get()));
     }
 
     public static final VoxelShape SHAPE = Stream.of(

--- a/src/main/java/de/tobfal/basicgens/block/IronGeneratorBlock.java
+++ b/src/main/java/de/tobfal/basicgens/block/IronGeneratorBlock.java
@@ -2,14 +2,19 @@ package de.tobfal.basicgens.block;
 
 import de.tobfal.basicgens.block.entity.GeneratorBlockEntityBase;
 import de.tobfal.basicgens.block.entity.IronGeneratorBlockEntity;
+import de.tobfal.basicgens.init.Config;
 import de.tobfal.basicgens.init.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -27,6 +32,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class IronGeneratorBlock extends BaseEntityBlock {
@@ -36,6 +43,15 @@ public class IronGeneratorBlock extends BaseEntityBlock {
     public IronGeneratorBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH));
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void appendHoverText(ItemStack stack, @Nullable BlockGetter blockGetter, List<Component> components, TooltipFlag tooltipFlag) {
+        components.add(Component.literal("Converts burnable items to RF power."));
+        components.add(Component.literal("Capacity: " + Config.IRON_GENERATOR_CAPACITY.get()));
+        components.add(Component.literal("RF/t: " + Config.IRON_GENERATOR_PERTICK.get()));
+        components.add(Component.literal("Output/t: " + Config.IRON_GENERATOR_TRANSFER.get()));
     }
 
     public static final VoxelShape SHAPE = Stream.of(

--- a/src/main/java/de/tobfal/basicgens/block/NetherGeneratorBlock.java
+++ b/src/main/java/de/tobfal/basicgens/block/NetherGeneratorBlock.java
@@ -1,15 +1,20 @@
 package de.tobfal.basicgens.block;
 
 import de.tobfal.basicgens.block.entity.NetherGeneratorBlockEntity;
+import de.tobfal.basicgens.init.Config;
 import de.tobfal.basicgens.init.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -27,6 +32,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class NetherGeneratorBlock extends BaseEntityBlock {
@@ -36,6 +43,15 @@ public class NetherGeneratorBlock extends BaseEntityBlock {
     public NetherGeneratorBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH));
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void appendHoverText(ItemStack stack, @Nullable BlockGetter blockGetter, List<Component> components, TooltipFlag tooltipFlag) {
+        components.add(Component.literal("Converts hot fluids into RF power."));
+        components.add(Component.literal("Capacity: " + Config.NETHER_GENERATOR_CAPACITY.get()));
+        components.add(Component.literal("RF/t: " + Config.NETHER_GENERATOR_PERTICK.get()));
+        components.add(Component.literal("Output/t: " + Config.NETHER_GENERATOR_TRANSFER.get()));
     }
 
     public static final VoxelShape SHAPE = Stream.of(

--- a/src/main/java/de/tobfal/basicgens/block/StoneGeneratorBlock.java
+++ b/src/main/java/de/tobfal/basicgens/block/StoneGeneratorBlock.java
@@ -2,14 +2,19 @@ package de.tobfal.basicgens.block;
 
 import de.tobfal.basicgens.block.entity.GeneratorBlockEntityBase;
 import de.tobfal.basicgens.block.entity.StoneGeneratorBlockEntity;
+import de.tobfal.basicgens.init.Config;
 import de.tobfal.basicgens.init.ModBlockEntities;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -26,6 +31,8 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import net.minecraftforge.network.NetworkHooks;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 import java.util.stream.Stream;
 
 public class StoneGeneratorBlock extends BaseEntityBlock {
@@ -35,6 +42,15 @@ public class StoneGeneratorBlock extends BaseEntityBlock {
     public StoneGeneratorBlock(Properties properties) {
         super(properties);
         this.registerDefaultState(this.getStateDefinition().any().setValue(FACING, Direction.NORTH));
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void appendHoverText(ItemStack stack, @Nullable BlockGetter blockGetter, List<Component> components, TooltipFlag tooltipFlag) {
+        components.add(Component.literal("Converts burnable items to RF power."));
+        components.add(Component.literal("Capacity: " + Config.STONE_GENERATOR_CAPACITY.get()));
+        components.add(Component.literal("RF/t: " + Config.STONE_GENERATOR_PERTICK.get()));
+        components.add(Component.literal("Output/t: " + Config.STONE_GENERATOR_TRANSFER.get()));
     }
 
     public static final VoxelShape SHAPE = Stream.of(


### PR DESCRIPTION
### Problem:

Currently, the mod doesn't include a very intuitive way of checking the generator stats like the amount of RF/t, etc.

### Solution:

Include item tooltips to inform the player by hovering over the item.


### Done:

- Add tooltips for `capacity`, `RF/t`, `Output/t`
- Add tooltips to identify the difference between the `Fluid` based generator and the `Burnable` based generator.

### Example:

![Screenshot_20220805_190816](https://user-images.githubusercontent.com/101365429/183135663-2deb4d00-ee72-420f-a96a-41d75004483b.png)
